### PR TITLE
Relicense content under CC BY 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,27 @@
-MIT License
+Creative Commons Attribution 4.0 International (CC BY 4.0)
 
-Copyright (c) 2021 Cotes Chung
+Copyright (c) 2023-2026 Nicolas LHOMME
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The content of this blog — articles, images, and any other original
+material authored by Nicolas LHOMME — is licensed under the Creative
+Commons Attribution 4.0 International License (CC BY 4.0).
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+You are free to:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  - Share — copy and redistribute the material in any medium or format
+  - Adapt — remix, transform, and build upon the material
+    for any purpose, even commercially.
+
+Under the following terms:
+
+  - Attribution — You must give appropriate credit, provide a link to
+    the license, and indicate if changes were made. You may do so in
+    any reasonable manner, but not in any way that suggests the
+    licensor endorses you or your use.
+
+No additional restrictions — You may not apply legal terms or
+technological measures that legally restrict others from doing
+anything the license permits.
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode
+Summary:           https://creativecommons.org/licenses/by/4.0/

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Every push to `main` triggers a build and deploy.
 
 ## License
 
-[MIT](LICENSE).
+Content is licensed under [CC BY 4.0](LICENSE).


### PR DESCRIPTION
- Replace the inherited MIT license (still crediting the Chirpy theme author) with **CC BY 4.0**, which is a better fit for blog articles and other prose content.
- Update `README.md` to point at the new license.
- [x] `LICENSE` shows CC BY 4.0 with copyright to Nicolas LHOMME
- [x] `README.md` license section updated
🤖 Generated with [Claude Code](https://claude.com/claude-code)